### PR TITLE
Add Linux, Mac, and WASM CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_and_test_native:
+    name: Native Build ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: cargo build --verbose
+      - run: cargo test --verbose
+  build_wasm:
+    name: WASM Build ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - wasm32-wasi
+          - wasm32-unknown-unknown
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustup target add ${{ matrix.target }}
+      - run: cargo build --verbose --target ${{ matrix.target }} --no-default-features


### PR DESCRIPTION
This PR adds a GitHub Actions config that:

- builds and tests on Linux and Mac
- builds on `wasm32-wasi` and `wasm32-unknown-unknown`