### PR TITLE
Remove localfs from default features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
           - ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: cargo build --verbose
-      - run: cargo test --verbose
+      - run: cargo build --verbose --features full
+      - run: cargo test --verbose --features full
   build_wasm:
     name: WASM Build ${{ matrix.target }}
     runs-on: ubuntu-latest
@@ -33,4 +33,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: rustup target add ${{ matrix.target }}
-      - run: cargo build --verbose --target ${{ matrix.target }} --no-default-features
+      - run: cargo build --verbose --target ${{ matrix.target }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,6 @@ path-clean = "0.1"
 serde = { version = "1.0", features = ["derive"], optional = true }
 
 [features]
-default = ["localfs"]
+full = ["localfs"]
 localfs = ["tokio/fs", "tokio/io-util", "tokio/rt", "tokio/macros"]
 serde = ["dep:serde"]

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ let local_fs = LocalFS::new();
 // on your local filesystem
 let local_fs = LocalFS::with_base_dir("/tmp");
 ```
+
+*Note: using `LocalFS` requires the `localfs` feature*
+
 ## Step 2: Use it instead of `tokio::fs::...`
 
 Instead of

--- a/src/localfs.rs
+++ b/src/localfs.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Note this module requires the `localfs` feature (which is enabled by default)
+//! Note this module requires the `localfs` feature
 
 use async_trait::async_trait;
 use path_clean::PathClean;


### PR DESCRIPTION
This PR removes `localfs` as a default feature.

This is a breaking change, but the benefits of doing this change now seem to outweigh the drawbacks (lunchbox is very early and doesn't yet have any dependents on crates.io so the breakage will be minimal if any)