### PR TITLE
Remove Send and Sync bounds when building for WASM

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ High level features:
 - Support for read only filesystems and read/write filesystems
 - A built-in implementation for local filesystems
 - An async interface
+- WASM support
 
 
 # Getting started
@@ -142,3 +143,7 @@ pub trait WritableFile: ReadableFile + AsyncWrite {
 ```
 
 Note that all `WritableFile`s must be `ReadableFile`s and all `WritableFileSystem`s must be `ReadableFileSystem`s as well.
+
+## WASM
+
+For WASM builds, the `Send` and `Sync` bounds are removed from all parts of the interface.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,20 @@
 
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/README_processed.md"))]
 
+macro_rules! if_wasm {
+    ($($item:item)*) => {$(
+        #[cfg(target_family = "wasm")]
+        $item
+    )*}
+}
+
+macro_rules! if_not_wasm {
+    ($($item:item)*) => {$(
+        #[cfg(not(target_family = "wasm"))]
+        $item
+    )*}
+}
+
 #[cfg(feature = "localfs")]
 pub mod localfs;
 pub mod path;


### PR DESCRIPTION
The `Send` and `Sync` bounds introduced by `async_trait` cause problems when trying to use lunchbox on wasm targets. 

This PR removes these bounds for wasm builds.