### PR TITLE
Add initial implementation of `chroot` utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+.vscode/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,10 +20,96 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bytes"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+
+[[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.144"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "lunchbox"
@@ -33,6 +119,7 @@ dependencies = [
  "path-clean",
  "relative-path",
  "serde",
+ "tempfile",
  "thiserror",
  "tokio",
 ]
@@ -74,10 +161,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "relative-path"
 version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3bf6b372449361333ac1f498b7edae4dd5e70dccd7c0c2a7c7bce8f05ede648"
+
+[[package]]
+name = "rustix"
+version = "0.37.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "serde"
@@ -111,6 +221,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,7 +264,7 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -167,53 +290,143 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ relative-path = "1.7"
 path-clean = "0.1"
 serde = { version = "1.0", features = ["derive"], optional = true }
 
+[dev-dependencies]
+tempfile = "3.3.0"
+
 [features]
 
 # All features

--- a/src/chroot.rs
+++ b/src/chroot.rs
@@ -1,0 +1,415 @@
+// Copyright 2023 Vivek Panyam
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Result;
+use std::sync::Arc;
+use std::task::Poll;
+
+use async_trait::async_trait;
+use thiserror::Error;
+
+use crate::types::{Permissions, WritableFile};
+use crate::{
+    path::{Path, PathBuf},
+    types::{
+        DirEntry, HasFileType, MaybeSend, MaybeSync, Metadata, OpenOptions, PathType, ReadDir,
+        ReadDirPoller, ReadableFile,
+    },
+    ReadableFileSystem, WritableFileSystem,
+};
+
+/// Wraps a lunchbox filesystem to modify paths going into the filesystem
+/// and paths coming out of the filesystem to add or remove a prefix respectively.
+///
+/// For example, `let p = fs.canonicalize("/some/path").await?;` would be approximately
+/// translated to:
+/// ```
+/// let p = {
+///     let path = base_dir.join("some/path");
+///     let out = inner.canonicalize(path).await?;
+///     out.strip_prefix(base_dir)
+/// };
+/// ```
+///
+/// Note: this should NOT be used for security purposes. It is intended for convenience.
+pub struct ChrootFS<T> {
+    inner: T,
+    base_dir: PathBuf,
+}
+
+/// Used to support wrappers for a filesystem (e.g. Arc<T> where T is a filesystem)
+pub trait FSWrapper {
+    type F: HasFileType;
+
+    fn get(&self) -> &Self::F;
+}
+
+impl<T> FSWrapper for &T
+where
+    T: HasFileType,
+{
+    type F = T;
+
+    fn get(&self) -> &Self::F {
+        self
+    }
+}
+
+impl<T> FSWrapper for Arc<T>
+where
+    T: HasFileType,
+{
+    type F = T;
+
+    fn get(&self) -> &Self::F {
+        self.as_ref()
+    }
+}
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ChrootError {
+    /// Path `req` was not within the base directory `base`
+    #[error("Path ({req}) was not within the base directory ({base})")]
+    PathTranslationError { base: PathBuf, req: PathBuf },
+}
+
+impl<T> ChrootFS<T> {
+    pub fn new(inner: T, base_dir: PathBuf) -> Self {
+        Self { inner, base_dir }
+    }
+
+    /// Remove the base dir when returning paths
+    fn strip_base_dir(&self, path: impl PathType) -> Result<PathBuf> {
+        // Normalize the path. `clean` does this without touching the FS
+        let path = path.as_ref();
+        let cleaned = path_clean::clean(path.as_str());
+        let cleaned = Path::new(&cleaned);
+
+        // Attempt to strip the base_dir prefix
+        cleaned
+            .strip_prefix(&self.base_dir)
+            .map_err(|_| {
+                std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    ChrootError::PathTranslationError {
+                        base: self.base_dir.clone(),
+                        req: path.to_owned(),
+                    },
+                )
+            })
+            .map(|p| p.to_owned())
+    }
+
+    /// Add the base dir when taking paths as input
+    fn with_base_dir(&self, path: impl PathType) -> Result<PathBuf> {
+        // Join path to the base dir and normalize the path. `clean` does this
+        // without touching the FS so we don't provide any additional information
+        // by returning the cleaned path in error messages
+        let cleaned = Path::new(&path_clean::clean(
+            self.base_dir.join(path.as_ref()).as_str(),
+        ))
+        .to_owned();
+
+        // Make sure `path` is within the base dir
+        if cleaned.starts_with(&self.base_dir) {
+            Ok(cleaned)
+        } else {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                ChrootError::PathTranslationError {
+                    base: self.base_dir.clone(),
+                    req: path.as_ref().to_owned(),
+                },
+            ))
+        }
+    }
+}
+
+impl<T: FSWrapper> HasFileType for ChrootFS<T> {
+    type FileType = <<T as FSWrapper>::F as HasFileType>::FileType;
+}
+
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
+impl<T> ReadableFileSystem for ChrootFS<T>
+where
+    T: FSWrapper + MaybeSend + MaybeSync,
+    T::F: ReadableFileSystem + MaybeSend + MaybeSync,
+    <<T as FSWrapper>::F as HasFileType>::FileType: ReadableFile,
+    <<T as FSWrapper>::F as ReadableFileSystem>::ReadDirPollerType: MaybeSend,
+{
+    async fn open(&self, path: impl PathType) -> Result<Self::FileType>
+    where
+        Self::FileType: ReadableFile,
+    {
+        let path = self.with_base_dir(path)?;
+        self.inner.get().open(path).await
+    }
+
+    async fn canonicalize(&self, path: impl PathType) -> Result<PathBuf> {
+        let path = self.with_base_dir(path)?;
+        let out = self.inner.get().canonicalize(path).await?;
+
+        self.strip_base_dir(out).map(|p| p.to_owned())
+    }
+
+    async fn metadata(&self, path: impl PathType) -> Result<Metadata> {
+        let path = self.with_base_dir(path)?;
+        self.inner.get().metadata(path).await
+    }
+
+    async fn read(&self, path: impl PathType) -> Result<Vec<u8>> {
+        let path = self.with_base_dir(path)?;
+        self.inner.get().read(path).await
+    }
+
+    type ReadDirPollerType =
+        ChrootReadDirPoller<<<T as FSWrapper>::F as ReadableFileSystem>::ReadDirPollerType>;
+
+    async fn read_dir(
+        &self,
+        path: impl PathType,
+    ) -> Result<ReadDir<Self::ReadDirPollerType, Self>> {
+        let path = self.with_base_dir(path)?;
+        let inner_poller = self.inner.get().read_dir(path).await?.into_poller();
+        let poller = ChrootReadDirPoller {
+            inner: inner_poller,
+        };
+
+        Ok(ReadDir::new(poller, self))
+    }
+
+    async fn read_link(&self, path: impl PathType) -> Result<PathBuf> {
+        let path = self.with_base_dir(path)?;
+        let out = self.inner.get().read_link(path).await?;
+
+        self.strip_base_dir(out).map(|p| p.to_owned())
+    }
+
+    async fn read_to_string(&self, path: impl PathType) -> Result<String> {
+        let path = self.with_base_dir(path)?;
+        self.inner.get().read_to_string(path).await
+    }
+
+    async fn symlink_metadata(&self, path: impl PathType) -> Result<Metadata> {
+        let path = self.with_base_dir(path)?;
+        self.inner.get().symlink_metadata(path).await
+    }
+}
+
+pub struct ChrootReadDirPoller<P> {
+    inner: P,
+}
+
+impl<T, P> ReadDirPoller<ChrootFS<T>> for ChrootReadDirPoller<P>
+where
+    T: FSWrapper,
+    T::F: ReadableFileSystem,
+    <<T as FSWrapper>::F as HasFileType>::FileType: ReadableFile,
+    P: ReadDirPoller<T::F>,
+    ChrootFS<T>: ReadableFileSystem,
+    <ChrootFS<T> as HasFileType>::FileType: ReadableFile,
+{
+    fn poll_next_entry<'a>(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+        fs: &'a ChrootFS<T>,
+    ) -> std::task::Poll<Result<Option<crate::types::DirEntry<'a, ChrootFS<T>>>>> {
+        match self.inner.poll_next_entry(cx, fs.inner.get()) {
+            Poll::Ready(Ok(Some(entry))) => Poll::Ready(Ok(Some(DirEntry::new(
+                fs,
+                entry.file_name(),
+                fs.strip_base_dir(entry.path()).map(|p| p.to_owned())?,
+            )))),
+
+            // We can pass through these cases
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Ok(None)) => Poll::Ready(Ok(None)),
+            Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
+        }
+    }
+}
+
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
+impl<T> WritableFileSystem for ChrootFS<T>
+where
+    ChrootFS<T>: ReadableFileSystem,
+    T: FSWrapper + MaybeSend + MaybeSync,
+    T::F: WritableFileSystem + MaybeSend + MaybeSync,
+    <<T as FSWrapper>::F as HasFileType>::FileType: WritableFile,
+
+    // TODO: This shouldn't be necessary because these types
+    // are equal.
+    Self::FileType: From<<<T as FSWrapper>::F as HasFileType>::FileType>,
+{
+    async fn open_with_opts(
+        &self,
+        opts: &OpenOptions,
+        path: impl PathType,
+    ) -> Result<Self::FileType> {
+        let path = self.with_base_dir(path)?;
+
+        self.inner
+            .get()
+            .open_with_opts(opts, path)
+            .await
+            .map(|v| v.into())
+    }
+
+    async fn copy(&self, from: impl PathType, to: impl PathType) -> Result<u64> {
+        let from = self.with_base_dir(from)?;
+        let to = self.with_base_dir(to)?;
+
+        self.inner.get().copy(from, to).await
+    }
+
+    async fn create_dir(&self, path: impl PathType) -> Result<()> {
+        let path = self.with_base_dir(path)?;
+
+        self.inner.get().create_dir(path).await
+    }
+
+    async fn create_dir_all(&self, path: impl PathType) -> Result<()> {
+        let path = self.with_base_dir(path)?;
+
+        self.inner.get().create_dir_all(path).await
+    }
+
+    async fn hard_link(&self, src: impl PathType, dst: impl PathType) -> Result<()> {
+        let src = self.with_base_dir(src)?;
+        let dst = self.with_base_dir(dst)?;
+
+        self.inner.get().hard_link(src, dst).await
+    }
+
+    async fn remove_dir(&self, path: impl PathType) -> Result<()> {
+        let path = self.with_base_dir(path)?;
+
+        self.inner.get().remove_dir(path).await
+    }
+
+    async fn remove_dir_all(&self, path: impl PathType) -> Result<()> {
+        let path = self.with_base_dir(path)?;
+
+        self.inner.get().remove_dir_all(path).await
+    }
+
+    async fn remove_file(&self, path: impl PathType) -> Result<()> {
+        let path = self.with_base_dir(path)?;
+
+        self.inner.get().remove_file(path).await
+    }
+
+    async fn rename(&self, from: impl PathType, to: impl PathType) -> Result<()> {
+        let from = self.with_base_dir(from)?;
+        let to = self.with_base_dir(to)?;
+
+        self.inner.get().rename(from, to).await
+    }
+
+    async fn set_permissions(&self, path: impl PathType, perm: Permissions) -> Result<()> {
+        let path = self.with_base_dir(path)?;
+
+        self.inner.get().set_permissions(path, perm).await
+    }
+
+    async fn symlink(&self, src: impl PathType, dst: impl PathType) -> Result<()> {
+        let src = self.with_base_dir(src)?;
+        let dst = self.with_base_dir(dst)?;
+
+        self.inner.get().symlink(src, dst).await
+    }
+
+    async fn write(
+        &self,
+        path: impl PathType,
+        contents: impl AsRef<[u8]> + MaybeSend,
+    ) -> Result<()> {
+        let path = self.with_base_dir(path)?;
+
+        self.inner.get().write(path, contents).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ChrootFS;
+    use crate::path::Path;
+    use crate::LocalFS;
+    use crate::ReadableFileSystem;
+    use crate::WritableFileSystem;
+    use tokio::io::AsyncReadExt;
+    use tokio::io::AsyncWriteExt;
+
+    #[test]
+    /// Ensures that joining "absolute" paths to a prefix does not overwrite the prefix
+    fn test_path_join() {
+        let a = Path::new("/a/b/c");
+        let b = Path::new("/d/e/f");
+
+        assert_eq!(a.join(b), Path::new("/a/b/c/d/e/f"))
+    }
+
+    #[cfg(feature = "localfs")]
+    #[test]
+    fn test_conversions() {
+        let local = LocalFS::new().unwrap();
+        let fs = ChrootFS::new(&local, "/".into());
+        assert_eq!(fs.with_base_dir("/a/b/c").unwrap(), Path::new("/a/b/c"));
+        assert_eq!(fs.with_base_dir("a/b/c").unwrap(), Path::new("/a/b/c"));
+
+        let fs = ChrootFS::new(&local, "/tmp".into());
+        assert_eq!(fs.with_base_dir("/a/b/c").unwrap(), Path::new("/tmp/a/b/c"));
+        assert_eq!(fs.with_base_dir("a/b/c").unwrap(), Path::new("/tmp/a/b/c"));
+        assert!(fs.with_base_dir("../etc/passwd").is_err());
+
+        assert!(fs.strip_base_dir("/etc/passwd").is_err());
+        assert!(fs.strip_base_dir("/a/b/c").is_err());
+        assert!(fs.strip_base_dir("a/b/c").is_err());
+
+        assert_eq!(
+            fs.strip_base_dir("/tmp/a/b/c").unwrap(),
+            Path::new("/a/b/c")
+        );
+        assert_eq!(fs.strip_base_dir("/tmp/a/b/c").unwrap(), Path::new("a/b/c"));
+    }
+
+    #[cfg(feature = "localfs")]
+    #[tokio::test]
+    async fn test_basic_chroot() {
+        let fs = LocalFS::new().unwrap();
+
+        // Create a test directory
+        let tmpdir = tempfile::tempdir().unwrap();
+        let tmpdir_path =
+            crate::path::Path::new(tmpdir.path().to_str().unwrap().strip_prefix("/").unwrap());
+
+        // Create a test file
+        let mut file = fs.create(tmpdir_path.join("applesauce.txt")).await.unwrap();
+
+        // Write some sample data to it
+        file.write_all(b"some text").await.unwrap();
+        file.flush().await.unwrap();
+
+        // Open the file under chroot
+        let chroot = ChrootFS::new(&fs, tmpdir_path.into());
+        let mut file = chroot.open("applesauce.txt").await.unwrap();
+
+        let mut buffer = String::new();
+        file.read_to_string(&mut buffer).await.unwrap();
+
+        assert_eq!(buffer, "some text");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ macro_rules! if_not_wasm {
     )*}
 }
 
+pub mod chroot;
 #[cfg(feature = "localfs")]
 pub mod localfs;
 pub mod path;

--- a/src/types.rs
+++ b/src/types.rs
@@ -672,6 +672,10 @@ impl<'a, T: ReadDirPoller<F>, F: ReadableFileSystem> ReadDir<'a, T, F> {
     pub async fn next_entry(&mut self) -> Result<Option<DirEntry<F>>> {
         poll_fn(|cx| self.poller.poll_next_entry(cx, self.fs)).await
     }
+
+    pub(crate) fn into_poller(self) -> T {
+        self.poller
+    }
 }
 
 /// A structure representing a type of file with accessors for each file type.


### PR DESCRIPTION
This PR adds a `ChrootFS` struct that allows changing the effective root of a filesystem.

`ChrootFS` wraps another lunchbox filesystem and does path translation. Given a `base_dir`, it prefixes all paths provided as arguments with `base_dir` and modifies all returned paths to strip the `base_dir` prefix.

For example, if base_dir was `a/b/c`:

```rust
fs.canonicalize('/d/e/f').await
```

would approximately be translated to

```rust
inner.canonicalize(base_dir.join('d/e/f')).await.map(|p| p.strip_prefix(base_dir))
```

_Note: This is NOT intended to be used when security is important. It's more for convenience._ 

### Test Plan

This PR adds a few tests. The change was also tested as part of a larger project.