### PR TITLE
Async `with_base_dir` implementation in `LocalFS`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ use lunchbox::ReadableFileSystem;
 use lunchbox::LocalFS;
 
 // Create a lunchbox filesystem that uses the root of your local filesystem as its root
-let local_fs = LocalFS::new();
+let local_fs = LocalFS::new()?;
 
 // Create a lunchbox filesystem that uses `/tmp` as its root.
 // `/some/path` inside the filesystem would be translated to `/tmp/some/path`
 // on your local filesystem
-let local_fs = LocalFS::with_base_dir("/tmp");
+let local_fs = LocalFS::with_base_dir("/tmp").await?;
 ```
 
 *Note: using `LocalFS` requires the `localfs` feature*


### PR DESCRIPTION
This PR modifies `LocalFS::with_base_dir` to use an async version of the `is_dir` check instead of the sync version it previously used. It also adds a `LocalFS::with_base_dir_unchecked` function that does not do an `is_dir` check.

Fixes #9

### Breaking change rationale

This is technically a breaking change (as it makes a sync function into an async one), but I'm okay merging it for the following reasons:

- The project does not have many dependents yet (and the external ones I've found do not use `with_base_dir`).
- The break is fairly easy to fix (either switch to `with_base_dir` if you can easily use an async function or manually call `.is_dir()` on the path before you pass it into `with_base_dir_unchecked`)

For a project at this stage, this choice seems to make sense compared to the overhead of deprecating the function, introducing an async alternative, and waiting for a major release to remove the sync one (especially since any breakages will be found when doing a `cargo update` instead of during a random build).