### PR TITLE
Ensure `read_link` returns "absolute" paths

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -167,6 +167,9 @@ where
     /// ```
     /// Reads a symbolic link, returning the file that the link points to.
     ///
+    /// Note: this _MUST_ return an absolute path (i.e. relative to the filesystem root)
+    /// even if the link was stored internally within the filesystem as a relative one.
+    ///
     /// This is an async version of [`std::fs::read_link`]
     async fn read_link(&self, path: impl PathType) -> Result<PathBuf>;
 


### PR DESCRIPTION
Lunchbox uses the `relative_path` crate as a platform independent path library (instead of implementing one inside Lunchbox). As you might expect, `relative_path` doesn't support absolute paths.

This is a problem for symlinks.

On Unix systems, `read_link` generally returns the symlink target path that was stored. This could be relative to the symlink file or an absolute path.

Because the `relative_path` library doesn't give us a way to distinguish between those, we must enforce that `read_link` always returns a path relative to the filesystem root.

Hopefully we can improve this in the future.